### PR TITLE
Redis protocol error fix

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -194,6 +194,7 @@ module Resque
             Process.wait(@child)
           else
             procline "Processing #{job.queue} since #{Time.now.to_i}"
+            redis.client.reconnect   # New connection for the child
             perform(job, &block)
             exit! unless @cant_fork
           end


### PR DESCRIPTION
I believe the keep alive thread checker thingie uses redis in the parent process while the worker process performs the job. That causes issues cause the descriptor is shared in the redis client.

This reconnects the redis client after forking.
