### PR TITLE
Fix broken tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ rvm:
   - 1.8.7
   - 1.9.2
   - jruby
-  - rbx-2.0
+  - rbx-18mode
+  - rbx-19mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 rvm:
   - 1.8.7
   - 1.9.2
+  - 1.9.3
   - jruby
   - rbx-18mode
   - rbx-19mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
-  - jruby
+  - jruby-18mode
+  - jruby-19mode
   - rbx-18mode
   - rbx-19mode

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ group :test do
   gem "rake"
   gem "rack-test", "~> 0.5"
   gem "mocha", "~> 0.9.7"
-  gem "leftright", :platforms => :mri_18
   gem "yajl-ruby", "~>0.8.2", :platforms => :mri
   gem "json", "~>1.5.3", :platforms => [:jruby, :rbx]
   gem "hoptoad_notifier"

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,25 @@
+## 1.20.0 (2012-02-17)
+
+* Fixed demos for ruby 1.9 (@BMorearty, #445)
+* Fixed `#requeue` tests (@hone, #500)
+* Web UI: optional trailing slashes of URLs (@elisehuard, #449)
+* Allow * to appear anywhere in queue list (@tapajos, #405, #407)
+* Wait for child with specific PID (@jacobkg)
+* #decode raise takes a string when re-raising as a different exception class (Trevor Hart)
+* Use Sinatra's `pubilc_folder` if it exists (@defunkt, #420, #421)
+* Assign the job's worker before calling `before_fork` (@quirkey)
+* Fix Resque::Helpers#constantize to work correctly on 1.9.2 (@rtlong)
+* Added before & after hooks for dequeue (@humancopy, #398)
+* daemonize support using `ENV["BACKGROUND"]` (@chrisleishman)
+* requeue and remove failed jobs by queue name (@evanwhalen)
+* `-r` flag for resque-web for redis connection (@gjastrab)
+* Added `Resque.enqueue_to`: allows you to specif the queue and still run hooks (@dan-g)
+* Web UI: Set the default encoding to UTF-8 (@elubow)
+* fix finding worker pids on JRuby (John Andrews + Andrew Grieser)
+* Added distributed redis support (@stipple)
+* Added better failure hooks (@raykrueger)
+* Added before & after dequeue hooks (@humancopy)
+
 ## 1.19.0 (2011-09-01)
 
 * Added Airbrake (formerly Hoptoad) support.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,13 @@
+## 1.21.0 (2012-07-02)
+
+* Add a flag to make sure failure hooks are only ran once (jakemack, #546)
+* Support updated MultiJSON API (@twinturbo)
+* Fix worker logging in monit example config (@twinturbo)
+* loosen dependency of redis-namespace to 1.x, support for redis-rb 3.0.x
+* change '%' to '$' in the 'stop program' command for monit
+* UTF8 sanitize exception messages when there's a failure (@brianmario, #507)
+* don't share a redis connection between parent and child (@jsanders, #585)
+
 ## 1.20.0 (2012-02-17)
 
 * Fixed demos for ruby 1.9 (@BMorearty, #445)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,7 @@
 * loosen dependency of redis-namespace to 1.x, support for redis-rb 3.0.x
 * change '%' to '$' in the 'stop program' command for monit
 * UTF8 sanitize exception messages when there's a failure (@brianmario, #507)
-* don't share a redis connection between parent and child (@jsanders, #585)
+* don't share a redis connection between parent and child (@jsanders, #588)
 
 ## 1.20.0 (2012-02-17)
 

--- a/README.markdown
+++ b/README.markdown
@@ -210,7 +210,7 @@ loop do
   if job = reserve
     job.process
   else
-    sleep 5
+    sleep 5 # Polling frequency = 5 
   end
 end
 shutdown
@@ -274,6 +274,13 @@ worker is started.
 
     $ PIDFILE=./resque.pid BACKGROUND=yes QUEUE=file_serve \
         rake environment resque:work
+
+### Polling frequency
+
+You can pass an INTERVAL option which is a float representing the polling frequency. 
+The default is 5 seconds, but for a semi-active app you may want to use a smaller value.
+
+    $ INTERVAL=0.1 QUEUE=file_serve rake environment resque:work
 
 ### Priorities and Queue Lists
 

--- a/README.markdown
+++ b/README.markdown
@@ -491,7 +491,7 @@ HTTP basic auth).
 
 ### Rails 3
 
-You can also mount Resque on a subpath in your existing Rails 3 app by adding `require resque/server` to the top of your routes file or in an initializer then adding this to `routes.rb`:
+You can also mount Resque on a subpath in your existing Rails 3 app by adding `require 'resque/server'` to the top of your routes file or in an initializer then adding this to `routes.rb`:
 
 ``` ruby
 mount Resque::Server.new, :at => "/resque"

--- a/Rakefile
+++ b/Rakefile
@@ -20,18 +20,11 @@ require 'rake/testtask'
 
 task :default => :test
 
-if command?(:rg)
-  desc "Run the test suite with rg"
-  task :test do
-    Dir['test/**/*_test.rb'].each do |f|
-      sh("rg #{f}")
-    end
-  end
-else
-  Rake::TestTask.new do |test|
-    test.libs << "test"
-    test.test_files = FileList['test/**/*_test.rb']
-  end
+Rake::TestTask.new do |test|
+  test.verbose = true
+  test.libs << "test"
+  test.libs << "lib"
+  test.test_files = FileList['test/**/*_test.rb']
 end
 
 if command? :kicker

--- a/Rakefile
+++ b/Rakefile
@@ -67,5 +67,4 @@ task :publish do
   sh "git push origin v#{Resque::Version}"
   sh "git push origin master"
   sh "git clean -fd"
-  exec "rake pages"
 end

--- a/examples/demo/README.markdown
+++ b/examples/demo/README.markdown
@@ -33,7 +33,7 @@ You should see the following output:
 
 You can also use `VVERBOSE` (very verbose) if you want to see more:
 
-    $ VERBOSE=true QUEUE=default rake resque:work
+    $ VVERBOSE=true QUEUE=default rake resque:work
     *** Starting worker hostname:90399:default
     ** [05:55:09 2009-09-16] 90399: Registered signals
     ** [05:55:09 2009-09-16] 90399: Checking default

--- a/examples/demo/Rakefile
+++ b/examples/demo/Rakefile
@@ -1,4 +1,5 @@
 $LOAD_PATH.unshift File.dirname(__FILE__) + '/../../lib'
+$LOAD_PATH.unshift File.dirname(__FILE__) unless $LOAD_PATH.include?(File.dirname(__FILE__))
 require 'resque/tasks'
 require 'job'
 

--- a/examples/demo/config.ru
+++ b/examples/demo/config.ru
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require 'logger'
 $LOAD_PATH.unshift File.dirname(__FILE__) + '/../../lib'
+$LOAD_PATH.unshift File.dirname(__FILE__) unless $LOAD_PATH.include?(File.dirname(__FILE__))
 require 'app'
 require 'resque/server'
 

--- a/examples/monit/resque.monit
+++ b/examples/monit/resque.monit
@@ -1,6 +1,6 @@
 check process resque_worker_QUEUE
   with pidfile /data/APP_NAME/current/tmp/pids/resque_worker_QUEUE.pid
-  start program = "/usr/bin/env HOME=/home/user RACK_ENV=production PATH=/usr/local/bin:/usr/local/ruby/bin:/usr/bin:/bin:$PATH /bin/sh -l -c 'cd /data/APP_NAME/current; nohup bundle exec rake environment resque:work RAILS_ENV=production QUEUE=queue_name VERBOSE=1 PIDFILE=tmp/pids/resque_worker_QUEUE.pid & >> log/resque_worker_QUEUE.log 2>&1'" as uid deploy and gid deploy
+  start program = "/usr/bin/env HOME=/home/user RACK_ENV=production PATH=/usr/local/bin:/usr/local/ruby/bin:/usr/bin:/bin:$PATH /bin/sh -l -c 'cd /data/APP_NAME/current; nohup bundle exec rake environment resque:work RAILS_ENV=production QUEUE=queue_name VERBOSE=1 PIDFILE=tmp/pids/resque_worker_QUEUE.pid >> log/resque_worker_QUEUE.log 2>&1'" as uid deploy and gid deploy
   stop program = "/bin/sh -c 'cd /data/APP_NAME/current && kill -9 %(cat tmp/pids/resque_worker_QUEUE.pid) && rm -f tmp/pids/resque_worker_QUEUE.pid; exit 0;'"
   if totalmem is greater than 300 MB for 10 cycles then restart  # eating up memory?
   group resque_workers

--- a/examples/monit/resque.monit
+++ b/examples/monit/resque.monit
@@ -1,6 +1,6 @@
 check process resque_worker_QUEUE
   with pidfile /data/APP_NAME/current/tmp/pids/resque_worker_QUEUE.pid
   start program = "/usr/bin/env HOME=/home/user RACK_ENV=production PATH=/usr/local/bin:/usr/local/ruby/bin:/usr/bin:/bin:$PATH /bin/sh -l -c 'cd /data/APP_NAME/current; nohup bundle exec rake environment resque:work RAILS_ENV=production QUEUE=queue_name VERBOSE=1 PIDFILE=tmp/pids/resque_worker_QUEUE.pid >> log/resque_worker_QUEUE.log 2>&1'" as uid deploy and gid deploy
-  stop program = "/bin/sh -c 'cd /data/APP_NAME/current && kill -9 %(cat tmp/pids/resque_worker_QUEUE.pid) && rm -f tmp/pids/resque_worker_QUEUE.pid; exit 0;'"
+  stop program = "/bin/sh -c 'cd /data/APP_NAME/current && kill -9 $(cat tmp/pids/resque_worker_QUEUE.pid) && rm -f tmp/pids/resque_worker_QUEUE.pid; exit 0;'"
   if totalmem is greater than 300 MB for 10 cycles then restart  # eating up memory?
   group resque_workers

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -77,9 +77,7 @@ module Resque
 
   # Set a proc that will be called in the parent process before the
   # worker forks for the first time.
-  def before_first_fork=(before_first_fork)
-    @before_first_fork = before_first_fork
-  end
+  attr_writer :before_first_fork
 
   # The `before_fork` hook will be run in the **parent** process
   # before every job, so be careful- any changes you make will be
@@ -92,9 +90,7 @@ module Resque
   end
 
   # Set the before_fork proc.
-  def before_fork=(before_fork)
-    @before_fork = before_fork
-  end
+  attr_writer :before_fork
 
   # The `after_fork` hook will be run in the child process and is passed
   # the current job. Any changes you make, therefore, will only live as
@@ -107,9 +103,7 @@ module Resque
   end
 
   # Set the after_fork proc.
-  def after_fork=(after_fork)
-    @after_fork = after_fork
-  end
+  attr_writer :after_fork
 
   def to_s
     "Resque Client connected to #{redis_id}"

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -115,17 +115,12 @@ module Resque
     "Resque Client connected to #{redis_id}"
   end
 
+  attr_accessor :inline
+
   # If 'inline' is true Resque will call #perform method inline
   # without queuing it into Redis and without any Resque callbacks.
   # The 'inline' is false Resque jobs will be put in queue regularly.
-  def inline?
-    @inline
-  end
-  alias_method :inline, :inline?
-
-  def inline=(inline)
-    @inline = inline
-  end
+  alias :inline? :inline
 
   #
   # queue manipulation

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -13,6 +13,8 @@ require 'resque/job'
 require 'resque/worker'
 require 'resque/plugin'
 
+require 'resque/vendor/utf8_util'
+
 module Resque
   include Helpers
   extend self

--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -8,7 +8,7 @@ module Resque
           :failed_at => Time.now.strftime("%Y/%m/%d %H:%M:%S %Z"),
           :payload   => payload,
           :exception => exception.class.to_s,
-          :error     => exception.to_s,
+          :error     => UTF8Util.clean(exception.to_s),
           :backtrace => filter_backtrace(Array(exception.backtrace)),
           :worker    => worker.to_s,
           :queue     => queue

--- a/lib/resque/helpers.rb
+++ b/lib/resque/helpers.rb
@@ -29,7 +29,7 @@ module Resque
       begin
         ::MultiJson.decode(object)
       rescue ::MultiJson::DecodeError => e
-        raise DecodeException, e
+        raise DecodeException, e.message, e.backtrace
       end
     end
 

--- a/lib/resque/helpers.rb
+++ b/lib/resque/helpers.rb
@@ -22,7 +22,7 @@ module Resque
     # queue.
     def encode(object)
       if MultiJson.respond_to?(:dump) && MultiJson.respond_to?(:load)
-        MultiJson.load object
+        MultiJson.dump object
       else
         MultiJson.encode object
       end
@@ -35,7 +35,7 @@ module Resque
 
       begin
         if MultiJson.respond_to?(:dump) && MultiJson.respond_to?(:load)
-          MultiJson.dump object
+          MultiJson.load object
         else
           MultiJson.decode object
         end

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -32,6 +32,7 @@ module Resque
     def initialize(queue, payload)
       @queue = queue
       @payload = payload
+      @failure_hooks_already_ran = false
     end
 
     # Creates a job by placing it on a queue. Expects a string queue
@@ -210,14 +211,16 @@ module Resque
       @after_hooks ||= Plugin.after_hooks(payload_class)
     end
 
-    def failure_hooks 
+    def failure_hooks
       @failure_hooks ||= Plugin.failure_hooks(payload_class)
     end
-    
-    def run_failure_hooks(exception)
-      job_args = args || []
-      failure_hooks.each { |hook| payload_class.send(hook, exception, *job_args) }
-    end
 
+    def run_failure_hooks(exception)
+      unless @failure_hooks_already_ran
+        job_args = args || []
+        failure_hooks.each { |hook| payload_class.send(hook, exception, *job_args) }
+        @failure_hooks_already_ran = true
+      end
+    end
   end
 end

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -216,9 +216,9 @@ module Resque
     end
 
     def run_failure_hooks(exception)
-      unless @failure_hooks_already_ran
-        job_args = args || []
-        failure_hooks.each { |hook| payload_class.send(hook, exception, *job_args) }
+      begin
+        failure_hooks.each { |hook| payload_class.send(hook, exception, *Array.wrap(args)) } unless @failure_hooks_already_ran
+      ensure
         @failure_hooks_already_ran = true
       end
     end

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -217,7 +217,8 @@ module Resque
 
     def run_failure_hooks(exception)
       begin
-        failure_hooks.each { |hook| payload_class.send(hook, exception, *Array.wrap(args)) } unless @failure_hooks_ran
+        job_args = args || []
+        failure_hooks.each { |hook| payload_class.send(hook, exception, *job_args) } unless @failure_hooks_ran
       ensure
         @failure_hooks_ran = true
       end

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -32,7 +32,7 @@ module Resque
     def initialize(queue, payload)
       @queue = queue
       @payload = payload
-      @failure_hooks_already_ran = false
+      @failure_hooks_ran = false
     end
 
     # Creates a job by placing it on a queue. Expects a string queue
@@ -217,9 +217,9 @@ module Resque
 
     def run_failure_hooks(exception)
       begin
-        failure_hooks.each { |hook| payload_class.send(hook, exception, *Array.wrap(args)) } unless @failure_hooks_already_ran
+        failure_hooks.each { |hook| payload_class.send(hook, exception, *Array.wrap(args)) } unless @failure_hooks_ran
       ensure
-        @failure_hooks_already_ran = true
+        @failure_hooks_ran = true
       end
     end
   end

--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -149,21 +149,21 @@ module Resque
     end
 
     %w( overview workers ).each do |page|
-      get "/#{page}.poll" do
+      get "/#{page}.poll/?" do
         show_for_polling(page)
       end
 
-      get "/#{page}/:id.poll" do
+      get "/#{page}/:id.poll/?" do
         show_for_polling(page)
       end
     end
 
     %w( overview queues working workers key ).each do |page|
-      get "/#{page}" do
+      get "/#{page}/?" do
         show page
       end
 
-      get "/#{page}/:id" do
+      get "/#{page}/:id/?" do
         show page
       end
     end
@@ -173,7 +173,7 @@ module Resque
       redirect u('queues')
     end
 
-    get "/failed" do
+    get "/failed/?" do
       if Resque::Failure.url
         redirect Resque::Failure.url
       else
@@ -193,7 +193,7 @@ module Resque
       redirect u('failed')
     end
 
-    get "/failed/requeue/:index" do
+    get "/failed/requeue/:index/?" do
       Resque::Failure.requeue(params[:index])
       if request.xhr?
         return Resque::Failure.all(params[:index])['retried_at']
@@ -202,24 +202,24 @@ module Resque
       end
     end
 
-    get "/failed/remove/:index" do
+    get "/failed/remove/:index/?" do
       Resque::Failure.remove(params[:index])
       redirect u('failed')
     end
 
-    get "/stats" do
+    get "/stats/?" do
       redirect url_path("/stats/resque")
     end
 
-    get "/stats/:id" do
+    get "/stats/:id/?" do
       show :stats
     end
 
-    get "/stats/keys/:key" do
+    get "/stats/keys/:key/?" do
       show :stats
     end
 
-    get "/stats.txt" do
+    get "/stats.txt/?" do
       info = Resque.info
 
       stats = []

--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -13,7 +13,13 @@ module Resque
     dir = File.dirname(File.expand_path(__FILE__))
 
     set :views,  "#{dir}/server/views"
-    set :public, "#{dir}/server/public"
+
+    if respond_to? :public_folder
+      set :public_folder, "#{dir}/server/public"
+    else
+      set :public, "#{dir}/server/public"
+    end
+
     set :static, true
 
     helpers do

--- a/lib/resque/vendor/utf8_util.rb
+++ b/lib/resque/vendor/utf8_util.rb
@@ -1,0 +1,26 @@
+module UTF8Util
+  # use '?' intsead of the unicode replace char, since that is 3 bytes
+  # and can increase the string size if it's done a lot
+  REPLACEMENT_CHAR = "?"
+
+  # Replace invalid UTF-8 character sequences with a replacement character
+  #
+  # Returns self as valid UTF-8.
+  def self.clean!(str)
+    raise NotImplementedError
+  end
+
+  # Replace invalid UTF-8 character sequences with a replacement character
+  #
+  # Returns a copy of this String as valid UTF-8.
+  def self.clean(str)
+    clean!(str.dup)
+  end
+
+end
+
+if RUBY_VERSION <= '1.9'
+  require 'resque/vendor/utf8_util/utf8_util_18'
+else
+  require 'resque/vendor/utf8_util/utf8_util_19'
+end

--- a/lib/resque/vendor/utf8_util/utf8_util_18.rb
+++ b/lib/resque/vendor/utf8_util/utf8_util_18.rb
@@ -1,0 +1,91 @@
+require 'strscan'
+
+module UTF8Util
+  HIGH_BIT_RANGE = /[\x80-\xff]/
+
+  # Check if this String is valid UTF-8
+  #
+  # Returns true or false.
+  def self.valid?(str)
+    sc = StringScanner.new(str)
+
+    while sc.skip_until(HIGH_BIT_RANGE)
+      sc.pos -= 1
+
+      if !sequence_length(sc)
+        return false
+      end
+    end
+
+    true
+  end
+
+  # Replace invalid UTF-8 character sequences with a replacement character
+  #
+  # Returns self as valid UTF-8.
+  def self.clean!(str)
+    sc = StringScanner.new(str)
+    while sc.skip_until(HIGH_BIT_RANGE)
+      pos = sc.pos = sc.pos-1
+
+      if !sequence_length(sc)
+        str[pos] = REPLACEMENT_CHAR
+      end
+    end
+
+    str
+  end
+
+  # Validate the UTF-8 sequence at the current scanner position.
+  #
+  # scanner - StringScanner instance so we can advance the pointer as we verify.
+  #
+  # Returns The length in bytes of this UTF-8 sequence, false if invalid.
+  def self.sequence_length(scanner)
+    leader = scanner.get_byte[0]
+
+    if (leader >> 5) == 0x6
+      if check_next_sequence(scanner)
+        return 2
+      else
+        scanner.pos -= 1
+      end
+    elsif (leader >> 4) == 0x0e
+      if check_next_sequence(scanner)
+        if check_next_sequence(scanner)
+          return 3
+        else
+          scanner.pos -= 2
+        end
+      else
+        scanner.pos -= 1
+      end
+    elsif (leader >> 3) == 0x1e
+      if check_next_sequence(scanner)
+        if check_next_sequence(scanner)
+          if check_next_sequence(scanner)
+            return 4
+          else
+            scanner.pos -= 3
+          end
+        else
+          scanner.pos -= 2
+        end
+      else
+        scanner.pos -= 1
+      end
+    end
+
+    false
+  end
+
+  private
+
+  # Read another byte off the scanner oving the scan position forward one place
+  #
+  # Returns nothing.
+  def self.check_next_sequence(scanner)
+    byte = scanner.get_byte[0]
+    (byte >> 6) == 0x2
+  end
+end

--- a/lib/resque/vendor/utf8_util/utf8_util_19.rb
+++ b/lib/resque/vendor/utf8_util/utf8_util_19.rb
@@ -1,0 +1,5 @@
+module UTF8Util
+  def self.clean!(str)
+    str.force_encoding("binary").encode("UTF-8", :invalid => :replace, :undef => :replace, :replace => REPLACEMENT_CHAR)
+  end
+end

--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  Version = VERSION = '1.19.0'
+  Version = VERSION = '1.20.0'
 end

--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  Version = VERSION = '1.20.0'
+  Version = VERSION = '1.20.1'
 end

--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  Version = VERSION = '1.20.1'
+  Version = VERSION = '1.21.0'
 end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -140,6 +140,7 @@ module Resque
             Process.wait(@child)
           else
             procline "Processing #{job.queue} since #{Time.now.to_i}"
+            redis.client.reconnect # Don't share connection with parent
             perform(job, &block)
             exit! unless @cant_fork
           end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -89,6 +89,8 @@ module Resque
     # removed without needing to restart workers using this method.
     def initialize(*queues)
       @queues = queues.map { |queue| queue.to_s.strip }
+      @shutdown = nil
+      @paused = nil
       validate_queues
     end
 

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -135,7 +135,7 @@ module Resque
           if @child = fork
             srand # Reseeding
             procline "Forked #{@child} at #{Time.now.to_i}"
-            Process.wait
+            Process.wait(@child)
           else
             procline "Processing #{job.queue} since #{Time.now.to_i}"
             perform(job, &block)

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -210,7 +210,7 @@ module Resque
     # A splat ("*") means you want every queue (in alpha order) - this
     # can be useful for dynamically adding new queues.
     def queues
-      @queues[0] == "*" ? Resque.queues.sort : @queues
+      @queues.map {|queue| queue == "*" ? Resque.queues.sort : queue }.flatten.uniq
     end
 
     # Not every platform supports fork. Here we do our magic to

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -128,6 +128,7 @@ module Resque
 
         if not paused? and job = reserve
           log "got: #{job.inspect}"
+          job.worker = self
           run_hook :before_fork, job
           working_on job
 
@@ -160,6 +161,7 @@ module Resque
     def process(job = nil, &block)
       return unless job ||= reserve
 
+      job.worker = self
       working_on job
       perform(job, &block)
     ensure
@@ -388,7 +390,6 @@ module Resque
     # Given a job, tells Redis we're working on it. Useful for seeing
     # what workers are doing and when.
     def working_on(job)
-      job.worker = self
       data = encode \
         :queue   => job.queue,
         :run_at  => Time.now.strftime("%Y/%m/%d %H:%M:%S %Z"),

--- a/resque.gemspec
+++ b/resque.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = [ "LICENSE", "README.markdown" ]
   s.rdoc_options      = ["--charset=UTF-8"]
 
-  s.add_dependency "redis-namespace", "~> 1.0.2"
+  s.add_dependency "redis-namespace", "~> 1.0"
   s.add_dependency "vegas",           "~> 0.1.2"
   s.add_dependency "sinatra",         ">= 0.9.2"
   s.add_dependency "multi_json",      "~> 1.0"

--- a/resque.gemspec
+++ b/resque.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary           = "Resque is a Redis-backed queueing system."
   s.homepage          = "http://github.com/defunkt/resque"
   s.email             = "chris@ozmm.org"
-  s.authors           = [ "Chris Wanstrath" ]
+  s.authors           = [ "Chris Wanstrath", "Terence Lee" ]
 
   s.files             = %w( README.markdown Rakefile LICENSE HISTORY.md )
   s.files            += Dir.glob("lib/**/*")

--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -51,3 +51,9 @@ context "on GET to /stats/resque" do
 
   should_respond_with_success
 end
+
+context "also works with slash at the end" do
+  setup { get "/working/" }
+
+  should_respond_with_success
+end

--- a/test/resque_failure_redis_test.rb
+++ b/test/resque_failure_redis_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+require 'resque/failure/redis'
+
+context "Resque::Failure::Redis" do
+  setup do
+    @bad_string    = [39, 250, 141, 168, 138, 191, 52, 211, 159, 86, 93, 95, 39].map { |c| c.chr }.join
+    exception      = StandardError.exception(@bad_string)
+    worker         = Resque::Worker.new(:test)
+    queue          = "queue"
+    payload        = { "class" => Object, "args" => 3 }
+    @redis_backend = Resque::Failure::Redis.new(exception, worker, queue, payload)
+  end
+
+  test 'cleans up bad strings before saving the failure, in order to prevent errors on the resque UI' do
+    # test assumption: the bad string should not be able to round trip though JSON
+    assert_raises(MultiJson::DecodeError) {
+      MultiJson.decode(MultiJson.encode(@bad_string))
+    }
+
+    @redis_backend.save
+    Resque::Failure::Redis.all # should not raise an error
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -147,12 +147,14 @@ end
 class Time
   # Thanks, Timecop
   class << self
+    attr_accessor :fake_time
+
     alias_method :now_without_mock_time, :now
 
-    def now_with_mock_time
-      $fake_time || now_without_mock_time
+    def now
+      fake_time || now_without_mock_time
     end
-
-    alias_method :now, :now_with_mock_time
   end
+
+  self.fake_time = nil
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,12 +1,12 @@
 require 'rubygems'
-require 'bundler'
-Bundler.setup(:default, :test)
-Bundler.require(:default, :test)
 
 dir = File.dirname(File.expand_path(__FILE__))
 $LOAD_PATH.unshift dir + '/../lib'
 $TESTING = true
 require 'test/unit'
+
+require 'redis/namespace'
+require 'resque'
 
 begin
   require 'leftright'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 
-dir = File.dirname(File.expand_path(__FILE__))
-$LOAD_PATH.unshift dir + '/../lib'
+$dir = File.dirname(File.expand_path(__FILE__))
+$LOAD_PATH.unshift $dir + '/../lib'
 $TESTING = true
 require 'test/unit'
 
@@ -42,21 +42,22 @@ at_exit do
   processes = `ps -A -o pid,command | grep [r]edis-test`.split("\n")
   pids = processes.map { |process| process.split(" ")[0] }
   puts "Killing test redis server..."
-  `rm -f #{dir}/dump.rdb #{dir}/dump-cluster.rdb`
-  pids.each { |pid| Process.kill("KILL", pid.to_i) }
+  pids.each { |pid| Process.kill("TERM", pid.to_i) }
+  sleep(0.1)
+  system("rm -f #{$dir}/dump.rdb #{$dir}/dump-cluster.rdb")
   exit exit_code
 end
 
 if ENV.key? 'RESQUE_DISTRIBUTED'
   require 'redis/distributed'
   puts "Starting redis for testing at localhost:9736 and localhost:9737..."
-  `redis-server #{dir}/redis-test.conf`
-  `redis-server #{dir}/redis-test-cluster.conf`
+  `redis-server #{$dir}/redis-test.conf`
+  `redis-server #{$dir}/redis-test-cluster.conf`
   r = Redis::Distributed.new(['redis://localhost:9736', 'redis://localhost:9737'])
   Resque.redis = Redis::Namespace.new :resque, :redis => r
 else
   puts "Starting redis for testing at localhost:9736..."
-  `redis-server #{dir}/redis-test.conf`
+  `redis-server #{$dir}/redis-test.conf`
   Resque.redis = 'localhost:9736'
 end
 

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -432,7 +432,7 @@ context "Resque::Worker" do
     assert_equal 1, Resque::Failure.count
   end
 
-  it "reconnects to redis after fork" do
+  test "reconnects to redis after fork" do
     original_connection = Resque.redis.client.connection.instance_variable_get("@sock")
     @worker.work(0)
     assert_not_equal original_connection, Resque.redis.client.connection.instance_variable_get("@sock")

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -431,4 +431,10 @@ context "Resque::Worker" do
     assert_equal queue2, Resque::Failure.all(0)['queue']
     assert_equal 1, Resque::Failure.count
   end
+
+  it "reconnects to redis after fork" do
+    original_connection = Resque.redis.client.connection.instance_variable_get("@sock")
+    @worker.work(0)
+    assert_not_equal original_connection, Resque.redis.client.connection.instance_variable_get("@sock")
+  end
 end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -385,8 +385,8 @@ context "Resque::Worker" do
   
   test "requeue failed queue" do
     queue = 'good_job'
-    Resque::Failure.create(:exception => Exception.new, :worker => Resque::Worker.new(queue), :queue => queue, :payload => {'class' => GoodJob})
-    Resque::Failure.create(:exception => Exception.new, :worker => Resque::Worker.new(queue), :queue => 'some_job', :payload => {'class' => SomeJob})
+    Resque::Failure.create(:exception => Exception.new, :worker => Resque::Worker.new(queue), :queue => queue, :payload => {'class' => 'GoodJob'})
+    Resque::Failure.create(:exception => Exception.new, :worker => Resque::Worker.new(queue), :queue => 'some_job', :payload => {'class' => 'SomeJob'})
     Resque::Failure.requeue_queue(queue)
     assert Resque::Failure.all(0).has_key?('retried_at')
     assert !Resque::Failure.all(1).has_key?('retried_at')
@@ -395,9 +395,9 @@ context "Resque::Worker" do
   test "remove failed queue" do
     queue = 'good_job'
     queue2 = 'some_job'
-    Resque::Failure.create(:exception => Exception.new, :worker => Resque::Worker.new(queue), :queue => queue, :payload => {'class' => GoodJob})
-    Resque::Failure.create(:exception => Exception.new, :worker => Resque::Worker.new(queue2), :queue => queue2, :payload => {'class' => SomeJob})
-    Resque::Failure.create(:exception => Exception.new, :worker => Resque::Worker.new(queue), :queue => queue, :payload => {'class' => GoodJob})
+    Resque::Failure.create(:exception => Exception.new, :worker => Resque::Worker.new(queue), :queue => queue, :payload => {'class' => 'GoodJob'})
+    Resque::Failure.create(:exception => Exception.new, :worker => Resque::Worker.new(queue2), :queue => queue2, :payload => {'class' => 'SomeJob'})
+    Resque::Failure.create(:exception => Exception.new, :worker => Resque::Worker.new(queue), :queue => queue, :payload => {'class' => 'GoodJob'})
     Resque::Failure.remove_queue(queue)
     assert_equal queue2, Resque::Failure.all(0)['queue']
     assert_equal 1, Resque::Failure.count

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -115,6 +115,36 @@ context "Resque::Worker" do
     assert_equal 0, Resque.size(:blahblah)
   end
 
+  test "can work with wildcard at the end of the list" do
+    Resque::Job.create(:high, GoodJob)
+    Resque::Job.create(:critical, GoodJob)
+    Resque::Job.create(:blahblah, GoodJob)
+    Resque::Job.create(:beer, GoodJob)
+
+    worker = Resque::Worker.new(:critical, :high, "*")
+
+    worker.work(0)
+    assert_equal 0, Resque.size(:high)
+    assert_equal 0, Resque.size(:critical)
+    assert_equal 0, Resque.size(:blahblah)
+    assert_equal 0, Resque.size(:beer)
+  end
+
+  test "can work with wildcard at the middle of the list" do
+    Resque::Job.create(:high, GoodJob)
+    Resque::Job.create(:critical, GoodJob)
+    Resque::Job.create(:blahblah, GoodJob)
+    Resque::Job.create(:beer, GoodJob)
+
+    worker = Resque::Worker.new(:critical, "*", :high)
+
+    worker.work(0)
+    assert_equal 0, Resque.size(:high)
+    assert_equal 0, Resque.size(:critical)
+    assert_equal 0, Resque.size(:blahblah)
+    assert_equal 0, Resque.size(:beer)
+  end
+
   test "processes * queues in alphabetical order" do
     Resque::Job.create(:high, GoodJob)
     Resque::Job.create(:critical, GoodJob)

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -355,16 +355,22 @@ context "Resque::Worker" do
   end
 
   test "very verbose works in the afternoon" do
-    require 'time'
-    $last_puts = ""
-    $fake_time = Time.parse("15:44:33 2011-03-02")
-    singleton = class << @worker; self end
-    singleton.send :define_method, :puts, lambda { |thing| $last_puts = thing }
+    begin
+      require 'time'
+      last_puts = ""
+      Time.fake_time = Time.parse("15:44:33 2011-03-02")
 
-    @worker.very_verbose = true
-    @worker.log("some log text")
+      @worker.extend(Module.new {
+        define_method(:puts) { |thing| last_puts = thing }
+      })
 
-    assert_match /\*\* \[15:44:33 2011-03-02\] \d+: some log text/, $last_puts
+      @worker.very_verbose = true
+      @worker.log("some log text")
+
+      assert_match /\*\* \[15:44:33 2011-03-02\] \d+: some log text/, last_puts
+    ensure
+      Time.fake_time = nil
+    end
   end
 
   test "Will call an after_fork hook after forking" do

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -286,7 +286,7 @@ context "Resque::Worker" do
   test "knows when it started" do
     time = Time.now
     @worker.work(0) do
-      assert_equal time.to_s, @worker.started.to_s
+      assert Time.parse(@worker.started) - time < 0.1
     end
   end
 


### PR DESCRIPTION
Fixes two issues:
- A brittle test around `Time.now` calls, if the clock changes during the duration of the test.
- A Ruby SEGV in 1.9.3-p194 because `dir` is not happy inside the `at_exit` block; use a global instead.
